### PR TITLE
Fixup Call for Talks 2024

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -2,20 +2,11 @@
 
 At FOSDEM 2024 we're having the 3nd edition of a Devroom completely dedicated to the BEAM (and all languages running on it). [FOSDEM](https://fosdem.org/) is an annual conference about free and open source software, attended by over 5000 developers and open-source enthusiasts from all over the world.
 
-### When
+The Devroom will take place in the morning on Saturday, 3 February 2024, at [ULB (Campus
+Solbosch)](https://www.openstreetmap.org/node/1632534522), in Brussels, Belgium. Join us to enjoy
+interesting talks, demos and discussions about Erlang, Elixir, Gleam and the wonderful BEAM!
 
-On Saturday (morning), 3rd February 2024.
+If this has piqued your interest, please [submit your talk proposal here]({{< ref
+"call-for-talks.md" >}}). We hope to see you in Brussels!
 
-### Where
-
-[ULB Campus Solbosch (Brussels, Belgium)](https://www.openstreetmap.org/node/1632534522).<!--, in Room [H.1309 (Van Rijn)](https://nav.fosdem.org/l/h1309/@1,280.08,99.33,5)-->
-
-<!--
-### What
-
-We have a [great schedule]({{< ref "schedule.md" >}}) ready for you, so we hope to meet you in Brussels! 🇧🇪
-
-### Meetup
-
-On Saturday evening (4th February 2023), we're also organizing a BEAM Meetup. You can find all the details [here]({{< ref "meetup.md" >}}).
--->
+Last, but not least, be aware of FOSDEM’s [Code of Conduct](https://fosdem.org/2023/practical/conduct/).

--- a/content/call-for-talks.md
+++ b/content/call-for-talks.md
@@ -20,8 +20,8 @@ We invite authors to submit original, high-quality work with sufficient backgrou
 We welcome any talk proposals about BEAM-related projects. Topics of interest include, but are not limited to:
   - Languages running on the BEAM (Erlang, Elixir, Gleam, et al.)
       - Introduction to the language
-  - Recent features and roadmap
-  - Interesting libraries
+      - Recent features and roadmap
+      - Interesting libraries
   - Frameworks
   - Open Source projects that run on the BEAM
   - Tooling
@@ -39,27 +39,26 @@ Please specify your preferred slot length, but note that we could ask submitters
 
 ## Submission details
 
-Please be aware of the fact that Devroom talks at FOSDEM will be recorded. By submitting a proposal you agree to being recorded and to have your talk made available.
+Submit your proposal here: [https://pretalx.fosdem.org/fosdem-2024/cfp](https://pretalx.fosdem.org/fosdem-2024/cfp)
+
+When logged in, click on the ‘Submit a Proposal’ button to create your talk proposal. Before submitting your talk in Pretalx, please make sure that "Erlang, Elixir, Gleam and Friends" is selected as the Track.
 
 Submissions must include:
-  - Title (Event title in Pretalx)
+  - Title
   - Abstract
 
 These additional details must be included in the 'Submission notes' section:
 
   - Desired slot length (please specify if you're willing to accept a shorter slot if there's the need)
   - Expected prior knowledge / intended audience
-  - Speaker bio
   - Links to previous talks by the speaker (optional)
   - Links to code / slides / material for the talk (optional)
 
 Note that this year the submission system changed from Pentabarf to Pretalx and accounts were not migrated: you will have to create a new Pretalx account.
 
-Submit your proposal here: [https://pretalx.fosdem.org/fosdem-2024/cfp](https://pretalx.fosdem.org/fosdem-2024/cfp)
-
-When logged in, click on the ‘Submit a Proposal’ button to create your talk proposal. Before submitting your talk in Pretalx, please make sure that Erlang, Elixir, Gleam & Friends Devroom is selected as the Track, and also that the duration is the correct one.
-
 If you have issues with Pretalx any other questions do not despair! Reach us at erlang-devroom-manager at fosdem.org.
+
+Please be aware of the fact that Devroom talks at FOSDEM will be recorded. By submitting a proposal you agree to being recorded and to have your talk made available.
 
 ## Important dates
 


### PR DESCRIPTION
- Remove some things that are not needed anymore on Pretalx.
- Fix the indentation in the topics to match the indended one.
- Begin with the call for action and move the recording notice at the end.
- Restore the Call for Talks link in the homepage.